### PR TITLE
Add "list" command to show all available stacks

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -30,6 +30,10 @@ func New(dir string) *backend {
 	return &backend{f: f}
 }
 
+func (b *backend) FetchAll() ([]client.Stack, error) {
+	return b.f.FetchAll()
+}
+
 func (b *backend) Fetch(name string) ([]client.Stack, error) {
 	return b.f.Fetch(name)
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/eyeamera/stacker-cli/client"
+	"github.com/eyeamera/stacker-cli/stacker"
 )
 
 type backend struct {
@@ -30,11 +30,11 @@ func New(dir string) *backend {
 	return &backend{f: f}
 }
 
-func (b *backend) FetchAll() ([]client.Stack, error) {
+func (b *backend) FetchAll() ([]stacker.Stack, error) {
 	return b.f.FetchAll()
 }
 
-func (b *backend) Fetch(name string) ([]client.Stack, error) {
+func (b *backend) Fetch(name string) ([]stacker.Stack, error) {
 	return b.f.Fetch(name)
 }
 

--- a/backend/fetcher.go
+++ b/backend/fetcher.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"fmt"
 
-	"github.com/eyeamera/stacker-cli/client"
+	"github.com/eyeamera/stacker-cli/stacker"
 )
 
 type stack struct {
@@ -24,7 +24,7 @@ func (s *stack) Capabilities() []string {
 	return nil
 }
 func (s *stack) Region() string { return s.region }
-func (s *stack) Params() (client.StackParams, error) {
+func (s *stack) Params() ([]stacker.StackParam, error) {
 	return s.resolver.Resolve(s.rawParameters, s)
 }
 
@@ -38,19 +38,19 @@ func newFetcher(cs ConfigStore, ts TemplateStore, r ParamsResolver) *fetcher {
 	return &fetcher{cs, ts, r}
 }
 
-func (f *fetcher) FetchAll() ([]client.Stack, error) {
+func (f *fetcher) FetchAll() ([]stacker.Stack, error) {
 	stackConfigs, err := f.cs.FetchAll()
 	if err != nil {
-		return []client.Stack{}, fmt.Errorf("unable to fetch stacks: %s", err)
+		return []stacker.Stack{}, fmt.Errorf("unable to fetch stacks: %s", err)
 	}
 
 	return f.fetchTemplates(stackConfigs)
 }
 
-func (f *fetcher) Fetch(name string) ([]client.Stack, error) {
+func (f *fetcher) Fetch(name string) ([]stacker.Stack, error) {
 	stackConfigs, err := f.cs.Fetch(name)
 	if err != nil {
-		return []client.Stack{}, fmt.Errorf("unable to fetch stack %s: %s", name, err)
+		return []stacker.Stack{}, fmt.Errorf("unable to fetch stack %s: %s", name, err)
 	}
 
 	return f.fetchTemplates(stackConfigs)
@@ -58,8 +58,8 @@ func (f *fetcher) Fetch(name string) ([]client.Stack, error) {
 
 // Fetch the templates for each stack to get a final list of params,
 // and the template body
-func (f *fetcher) fetchTemplates(stackConfigs []stackConfig) ([]client.Stack, error) {
-	stacks := make([]client.Stack, 0)
+func (f *fetcher) fetchTemplates(stackConfigs []stackConfig) ([]stacker.Stack, error) {
+	stacks := make([]stacker.Stack, 0)
 	for _, stackConfig := range stackConfigs {
 		t, err := f.ts.Fetch(stackConfig.TemplateName)
 		if err != nil {

--- a/backend/fetcher.go
+++ b/backend/fetcher.go
@@ -38,15 +38,28 @@ func newFetcher(cs ConfigStore, ts TemplateStore, r ParamsResolver) *fetcher {
 	return &fetcher{cs, ts, r}
 }
 
-func (f *fetcher) Fetch(name string) ([]client.Stack, error) {
-	stacks := make([]client.Stack, 0)
-	stackConfigs, err := f.cs.Fetch(name)
+func (f *fetcher) FetchAll() ([]client.Stack, error) {
+	stackConfigs, err := f.cs.FetchAll()
 	if err != nil {
-		return stacks, fmt.Errorf("unable to fetch stack %s: %s", name, err)
+		return []client.Stack{}, fmt.Errorf("unable to fetch stacks: %s", err)
 	}
 
-	// Fetch the templates for each stack to get a final list of params,
-	// and the template body
+	return f.fetchTemplates(stackConfigs)
+}
+
+func (f *fetcher) Fetch(name string) ([]client.Stack, error) {
+	stackConfigs, err := f.cs.Fetch(name)
+	if err != nil {
+		return []client.Stack{}, fmt.Errorf("unable to fetch stack %s: %s", name, err)
+	}
+
+	return f.fetchTemplates(stackConfigs)
+}
+
+// Fetch the templates for each stack to get a final list of params,
+// and the template body
+func (f *fetcher) fetchTemplates(stackConfigs []stackConfig) ([]client.Stack, error) {
+	stacks := make([]client.Stack, 0)
 	for _, stackConfig := range stackConfigs {
 		t, err := f.ts.Fetch(stackConfig.TemplateName)
 		if err != nil {

--- a/backend/params.go
+++ b/backend/params.go
@@ -4,14 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/eyeamera/stacker-cli/client"
 	"github.com/pkg/errors"
-)
 
-// A subset of client.Stack available for resolvers
-type StackInfo interface {
-	Region() string
-}
+	"github.com/eyeamera/stacker-cli/stacker"
+)
 
 // Implements client.StackParam
 type stackParam struct {
@@ -26,10 +22,10 @@ func (sp *stackParam) UsePrevious() bool { return sp.usePrevious }
 
 type RawParams map[string]interface{}
 
-type Resolver func(key string, param interface{}, stack StackInfo) (client.StackParam, error)
+type Resolver func(key string, param interface{}, stack stacker.Stack) (stacker.StackParam, error)
 
 type ParamsResolver interface {
-	Resolve(rp RawParams, stack StackInfo) (client.StackParams, error)
+	Resolve(rp RawParams, stack stacker.Stack) ([]stacker.StackParam, error)
 }
 
 type paramsResolver struct {
@@ -46,8 +42,8 @@ func (pr *paramsResolver) Add(key string, r Resolver) {
 	pr.resolvers[key] = r
 }
 
-func (pr *paramsResolver) Resolve(rp RawParams, stack StackInfo) (client.StackParams, error) {
-	sp := make(client.StackParams, 0)
+func (pr *paramsResolver) Resolve(rp RawParams, stack stacker.Stack) ([]stacker.StackParam, error) {
+	sp := make([]stacker.StackParam, 0)
 	for k, v := range rp {
 		r, err := pr.resolve(k, v, stack)
 		if err != nil {
@@ -59,7 +55,7 @@ func (pr *paramsResolver) Resolve(rp RawParams, stack StackInfo) (client.StackPa
 	return sp, nil
 }
 
-func (pr *paramsResolver) resolve(k string, v interface{}, stack StackInfo) (client.StackParam, error) {
+func (pr *paramsResolver) resolve(k string, v interface{}, stack stacker.Stack) (stacker.StackParam, error) {
 	original := reflect.ValueOf(v)
 	switch original.Kind() {
 	case reflect.Map:

--- a/backend/resolvers.go
+++ b/backend/resolvers.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/eyeamera/stacker-cli/client"
 	"github.com/pkg/errors"
+
+	"github.com/eyeamera/stacker-cli/client"
+	"github.com/eyeamera/stacker-cli/stacker"
 )
 
 // ResolveStackOutput provides a mechanism to lookup an output from a stack within
@@ -20,7 +22,7 @@ import (
 //       Stack: Foo-VPC.VpcID
 //
 // where 'Foo-VPC' is the stack name, and 'VpcId' is the stack output
-func ResolveStackOutput(key string, param interface{}, stack StackInfo) (client.StackParam, error) {
+func ResolveStackOutput(key string, param interface{}, stack stacker.Stack) (stacker.StackParam, error) {
 	s := strings.SplitN(fmt.Sprint(param), ".", 2)
 	if len(s) != 2 {
 		return nil, fmt.Errorf("expected to receive input in format <stack>.<output>")
@@ -42,7 +44,7 @@ func ResolveStackOutput(key string, param interface{}, stack StackInfo) (client.
 	return nil, fmt.Errorf("unable to find output `%s` on stack `%s`", outputName, stackName)
 }
 
-func ResolveFile(key string, param interface{}, stack StackInfo) (client.StackParam, error) {
+func ResolveFile(key string, param interface{}, stack stacker.Stack) (stacker.StackParam, error) {
 	path := fmt.Sprint(param)
 	r, err := os.Open(path)
 	if err != nil {

--- a/client/cloudformation.go
+++ b/client/cloudformation.go
@@ -19,6 +19,7 @@ type CloudformationClient interface {
 	ExecuteChangeSet(*cf.ExecuteChangeSetInput) (*cf.ExecuteChangeSetOutput, error)
 	GetTemplate(*cf.GetTemplateInput) (*cf.GetTemplateOutput, error)
 	ListChangeSets(input *cf.ListChangeSetsInput) (*cf.ListChangeSetsOutput, error)
+	ListStacksPages(input *cf.ListStacksInput, fn func(*cf.ListStacksOutput, bool) bool) error
 	WaitUntilChangeSetCreateCompleteWithContext(ctx aws.Context, input *cf.DescribeChangeSetInput, opts ...request.WaiterOption) error
 }
 

--- a/cmd/stacker/commands/commands.go
+++ b/cmd/stacker/commands/commands.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/eyeamera/stacker-cli/client"
+	"github.com/eyeamera/stacker-cli/stacker"
 	"github.com/fatih/color"
 	"github.com/jawher/mow.cli"
 	"github.com/olekukonko/tablewriter"
@@ -30,8 +31,8 @@ func newStackerClient(region string) *client.Client {
 }
 
 type Backend interface {
-	FetchAll() ([]client.Stack, error)
-	Fetch(name string) ([]client.Stack, error)
+	FetchAll() ([]stacker.Stack, error)
+	Fetch(name string) ([]stacker.Stack, error)
 }
 
 func List(b Backend) func(cmd *cli.Cmd) {
@@ -60,8 +61,8 @@ func List(b Backend) func(cmd *cli.Cmd) {
 func Update(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack            client.Stack
-			stacker          *client.Client
+			stack            stacker.Stack
+			stackerCli       *client.Client
 			stackName        = cmd.StringArg("STACK", "", "Stack name")
 			allowDestructive = cmd.Bool(cli.BoolOpt{
 				Name:  "y allow-destructive",
@@ -74,22 +75,22 @@ func Update(b Backend) func(cmd *cli.Cmd) {
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
+			stackerCli = newStackerClient(stack.Region())
 		}
 
 		cmd.Action = func() {
-			cs, err := plan(stacker, stack)
+			cs, err := plan(stackerCli, stack)
 			if err != nil {
 				exitWithError(err)
 			}
 
-			review(stacker, cs)
+			review(stackerCli, cs)
 
 			if !confirmChanges(cs, *allowDestructive) {
 				os.Exit(1)
 			}
 
-			if err := apply(stacker, cs); err != nil {
+			if err := apply(stackerCli, cs); err != nil {
 				exitWithError(err)
 			}
 
@@ -101,20 +102,20 @@ func Update(b Backend) func(cmd *cli.Cmd) {
 func Plan(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack     client.Stack
-			stacker   *client.Client
-			stackName = cmd.StringArg("STACK", "", "Stack name")
+			stack      stacker.Stack
+			stackerCli *client.Client
+			stackName  = cmd.StringArg("STACK", "", "Stack name")
 		)
 
 		cmd.Spec = "STACK"
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
+			stackerCli = newStackerClient(stack.Region())
 		}
 
 		cmd.Action = func() {
-			cs, err := plan(stacker, stack)
+			cs, err := plan(stackerCli, stack)
 			if err != nil {
 				exitWithError(err)
 			}
@@ -141,10 +142,10 @@ func Plan(b Backend) func(cmd *cli.Cmd) {
 func Review(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack     client.Stack
-			stacker   *client.Client
-			stackName = cmd.StringArg("STACK", "", "Stack name")
-			changeSet = cmd.StringArg("CHANGESET", "", "Changeset name")
+			stack      stacker.Stack
+			stackerCli *client.Client
+			stackName  = cmd.StringArg("STACK", "", "Stack name")
+			changeSet  = cmd.StringArg("CHANGESET", "", "Changeset name")
 		)
 
 		// @TODO Allow stack to not exist locally for this
@@ -153,17 +154,17 @@ func Review(b Backend) func(cmd *cli.Cmd) {
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
-			ensureStackExists(stacker, *stackName)
+			stackerCli = newStackerClient(stack.Region())
+			ensureStackExists(stackerCli, *stackName)
 		}
 
 		cmd.Action = func() {
-			cs, err := fetchChangeSet(stacker, *stackName, *changeSet)
+			cs, err := fetchChangeSet(stackerCli, *stackName, *changeSet)
 			if err != nil {
 				exitWithError(err)
 			}
 
-			review(stacker, cs)
+			review(stackerCli, cs)
 
 			if !cs.CanCommit() {
 				return
@@ -181,8 +182,8 @@ func Review(b Backend) func(cmd *cli.Cmd) {
 func Apply(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack            client.Stack
-			stacker          *client.Client
+			stack            stacker.Stack
+			stackerCli       *client.Client
 			stackName        = cmd.StringArg("STACK", "", "Stack name")
 			changeSet        = cmd.StringArg("CHANGESET", "", "Changeset name")
 			allowDestructive = cmd.Bool(cli.BoolOpt{
@@ -198,23 +199,23 @@ func Apply(b Backend) func(cmd *cli.Cmd) {
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
-			ensureStackExists(stacker, *stackName)
+			stackerCli = newStackerClient(stack.Region())
+			ensureStackExists(stackerCli, *stackName)
 		}
 
 		cmd.Action = func() {
-			cs, err := fetchChangeSet(stacker, *stackName, *changeSet)
+			cs, err := fetchChangeSet(stackerCli, *stackName, *changeSet)
 			if err != nil {
 				exitWithError(err)
 			}
 
-			review(stacker, cs)
+			review(stackerCli, cs)
 
 			if !confirmChanges(cs, *allowDestructive) {
 				os.Exit(1)
 			}
 
-			if err := apply(stacker, cs); err != nil {
+			if err := apply(stackerCli, cs); err != nil {
 				exitWithError(err)
 			}
 
@@ -232,9 +233,9 @@ func Apply(b Backend) func(cmd *cli.Cmd) {
 func Delete(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack     client.Stack
-			stacker   *client.Client
-			stackName = cmd.StringArg("STACK", "", "Stack name")
+			stack      stacker.Stack
+			stackerCli *client.Client
+			stackName  = cmd.StringArg("STACK", "", "Stack name")
 		)
 
 		// @TODO Allow stack to not exist locally for this
@@ -243,8 +244,8 @@ func Delete(b Backend) func(cmd *cli.Cmd) {
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
-			ensureStackExists(stacker, *stackName)
+			stackerCli = newStackerClient(stack.Region())
+			ensureStackExists(stackerCli, *stackName)
 		}
 
 		cmd.Action = func() {
@@ -259,7 +260,7 @@ func Delete(b Backend) func(cmd *cli.Cmd) {
 
 			fmt.Println()
 
-			if err := deleteStack(stacker, *stackName); err != nil {
+			if err := deleteStack(stackerCli, *stackName); err != nil {
 				exitWithError(err)
 			}
 		}
@@ -269,34 +270,34 @@ func Delete(b Backend) func(cmd *cli.Cmd) {
 func Show(b Backend) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		var (
-			stack     client.Stack
-			stacker   *client.Client
-			stackName = cmd.StringArg("STACK", "", "Stack name")
+			stack      stacker.Stack
+			stackerCli *client.Client
+			stackName  = cmd.StringArg("STACK", "", "Stack name")
 		)
 
 		cmd.Spec = "STACK"
 
 		cmd.Before = func() {
 			stack = fetchStack(b, *stackName)
-			stacker = newStackerClient(stack.Region())
-			ensureStackExists(stacker, *stackName)
+			stackerCli = newStackerClient(stack.Region())
+			ensureStackExists(stackerCli, *stackName)
 		}
 
 		cmd.Action = func() {
-			if err := show(stacker, *stackName); err != nil {
+			if err := show(stackerCli, *stackName); err != nil {
 				exitWithError(err)
 			}
 		}
 	}
 }
 
-func fetchLocal(b Backend) ([]client.Stack, error) {
+func fetchLocal(b Backend) ([]stacker.Stack, error) {
 	stacks, err := b.FetchAll()
 	if err != nil {
 		return nil, err
 	}
 
-	sort.Sort(client.StackList(stacks))
+	sort.Sort(stacker.StackList(stacks))
 	return stacks, nil
 }
 
@@ -311,7 +312,7 @@ func fetchRemote(region string) ([]*client.StackInfo, error) {
 	return stacks, nil
 }
 
-func compareWithRemote(local []client.Stack) ([]string, error) {
+func compareWithRemote(local []stacker.Stack) ([]string, error) {
 	remoteByRegion := make(map[string][]*client.StackInfo)
 	for _, s := range local {
 		if _, ok := remoteByRegion[s.Region()]; ok {
@@ -409,7 +410,7 @@ func listRemote(b Backend, region string) error {
 	return nil
 }
 
-func fetchStack(b Backend, name string) client.Stack {
+func fetchStack(b Backend, name string) stacker.Stack {
 	s, err := b.Fetch(name)
 	if err != nil {
 		exitWithError(err)
@@ -427,7 +428,7 @@ func fetchStack(b Backend, name string) client.Stack {
 }
 
 // Plan creates a new changeset given a client and a stack
-func plan(stacker *client.Client, stack client.Stack) (*client.ChangeSetInfo, error) {
+func plan(stacker *client.Client, stack stacker.Stack) (*client.ChangeSetInfo, error) {
 	var (
 		si  *client.StackInfo
 		cs  *client.ChangeSetInfo

--- a/cmd/stacker/main.go
+++ b/cmd/stacker/main.go
@@ -18,15 +18,15 @@ func main() {
 
 	app := cli.App("stacker", "Manage Cloudformation Stacks")
 
-	// Require a stack
-	app.Command("update", "Update performs a plan, review and an apply on a stack", commands.Update(b))
-	app.Command("plan", "Plan a change to a stack by creating a changeset", commands.Plan(b))
+	app.Command("list", "List available stacks", commands.List(b))
 
-	// Require a stack name + region
+	// Require a stack
+	app.Command("show", "Show information about a stack", commands.Show(b))
+	app.Command("plan", "Plan a change to a stack by creating a changeset", commands.Plan(b))
 	app.Command("review", "Review a changeset", commands.Review(b))
 	app.Command("apply", "Apply a changeset", commands.Apply(b))
+	app.Command("update", "Update performs a plan, review and an apply on a stack", commands.Update(b))
 	app.Command("delete", "Delete a stack", commands.Delete(b))
-	app.Command("show", "Show information about a stack", commands.Show(b))
 
 	app.Run(os.Args)
 }

--- a/stacker/stacker.go
+++ b/stacker/stacker.go
@@ -1,0 +1,35 @@
+package stacker
+
+// StackParam represents a stack parameter
+type StackParam interface {
+	Key() string
+	Value() string
+	UsePrevious() bool
+}
+
+// StackParams represents an set of StackParam
+type StackParams []StackParam
+
+// Stack interface for creating and updating stacks
+type Stack interface {
+	Name() string
+	Region() string
+	Params() ([]StackParam, error)
+	TemplateBody() string
+	Capabilities() []string
+}
+
+// Sortable list of Stacks
+type StackList []Stack
+
+func (s StackList) Len() int {
+	return len(s)
+}
+
+func (s StackList) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s StackList) Less(i, j int) bool {
+	return s[i].Name() < s[j].Name()
+}


### PR DESCRIPTION
An open question is whether this command should show stacks already in CF (like show does), or just the local stacks. Or maybe both, with status of creation? Currently this just lists local stacks.

![screen shot 2018-08-02 at 11 26 01 am](https://user-images.githubusercontent.com/145951/43603119-e59b92e8-9646-11e8-9792-81dd68f9f1ec.png)
![screen shot 2018-08-02 at 3 45 42 pm](https://user-images.githubusercontent.com/145951/43615146-26d8fc18-966b-11e8-85f6-cc0444be2328.png)
