### PR TITLE
Move to slice/array type for capabilities to allow for multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ stacks:
       AvailabilityZone: us-east-1b
 
   - name: API # The stack name implies the template # templates/API.{yml, yaml, json}
-    capabilities: CAPABILITY_IAM # give permission to create IAM resources
+    capabilities: [CAPABILITY_IAM] # give permission to create IAM resources
     parameters:
       Subnets: *PublicSubnets
 ```
@@ -90,7 +90,7 @@ Each stack configuration takes the following format:
 - name: StackName
   region: us-east-1
   template_name: NameOfTemplate
-  capabilities: CAPABILITY_IAM
+  capabilities: [CAPABILITY_IAM]
   parameters:
     Name: BestStack # Literal, string parameter
     FileDataParam:

--- a/backend/config.go
+++ b/backend/config.go
@@ -24,7 +24,7 @@ type stackConfig struct {
 	Name         string
 	Region       string
 	TemplateName string `yaml:"template_name"`
-	Capabilities string
+	Capabilities []string
 	Parameters   map[string]interface{}
 }
 

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -33,7 +33,7 @@ func TestConfigStoreInternalFetch(t *testing.T) {
 				stackConfig{
 					Name:         "Foo-VPC",
 					TemplateName: "VPC",
-					Capabilities: "CAPABILITIES_IAM",
+					Capabilities: []string{"CAPABILITIES_IAM"},
 					Parameters: map[string]interface{}{
 						"Bar":     "123abc",
 						"Name":    "ProductionVPC",
@@ -50,7 +50,7 @@ func TestConfigStoreInternalFetch(t *testing.T) {
 			Stacks: []stackConfig{
 				stackConfig{Name: "Foo-VPC",
 					TemplateName: "VPC",
-					Capabilities: "CAPABILITIES_IAM",
+					Capabilities: []string{"CAPABILITIES_IAM"},
 					Parameters: map[string]interface{}{
 						"VpcCIDR": "10.11.0.0/16",
 						"Name":    "SandboxVPC",

--- a/backend/fetcher.go
+++ b/backend/fetcher.go
@@ -9,21 +9,16 @@ import (
 type stack struct {
 	name          string
 	region        string
-	capabilities  string
+	capabilities  []string
 	templateBody  string
 	rawParameters RawParams
 	resolver      ParamsResolver
 }
 
-func (s *stack) Name() string         { return s.name }
-func (s *stack) TemplateBody() string { return s.templateBody }
-func (s *stack) Capabilities() []string {
-	if s.capabilities != "" {
-		return []string{s.capabilities}
-	}
-	return nil
-}
-func (s *stack) Region() string { return s.region }
+func (s *stack) Name() string           { return s.name }
+func (s *stack) TemplateBody() string   { return s.templateBody }
+func (s *stack) Capabilities() []string { return s.capabilities }
+func (s *stack) Region() string         { return s.region }
 func (s *stack) Params() ([]stacker.StackParam, error) {
 	return s.resolver.Resolve(s.rawParameters, s)
 }

--- a/test/stacker/environments/production/vpc.yml
+++ b/test/stacker/environments/production/vpc.yml
@@ -4,7 +4,7 @@ defaults:
     VpcCIDR: 10.21.0.0/16
 stacks:
   - name: Foo-VPC
-    capabilities: CAPABILITIES_IAM
+    capabilities: [CAPABILITIES_IAM]
     template_name: VPC
     parameters:
       Name: ProductionVPC

--- a/test/stacker/environments/sandbox.yml
+++ b/test/stacker/environments/sandbox.yml
@@ -3,7 +3,7 @@ defaults:
   parameters:
 stacks:
   - name: Foo-VPC
-    capabilities: CAPABILITIES_IAM
+    capabilities: [CAPABILITIES_IAM]
     template_name: VPC
     parameters:
       Name: SandboxVPC


### PR DESCRIPTION
This is a non-backwards compatible change, as all yml files will need to provide an array of capabilities, but better to start now.