### PR TITLE
Add "stacks" as valid yml config path

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -11,11 +11,20 @@ type backend struct {
 	f *fetcher
 }
 
-func New(dir string) *backend {
+var backendPaths = []string{
+	"environments",
+	"regions",
+	"stacks",
+}
 
-	confDir := path.Join(dir, "environments")
-	if !pathExists(confDir) {
-		confDir = path.Join(dir, "regions")
+func New(dir string) *backend {
+	var confDir string
+
+	for _, confPath := range backendPaths {
+		confDir = path.Join(dir, confPath)
+		if pathExists(confDir) {
+			break
+		}
 	}
 
 	cs := newConfigStore(confDir)


### PR DESCRIPTION
We may not want to support all three, but for our use-case "stacks" makes a bit more sense than "environments", since we're organizing by VPC and not an architectural environment. So then you have two main directories, stacks and templates.

I don't feel strongly about this, just wanted to propose it.